### PR TITLE
Add support to flex patch vanilla or the previous patch

### DIFF
--- a/tools/create_patch.py
+++ b/tools/create_patch.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import subprocess
+import zlib
+
+DEFAULT_XDELTA3_PATH = 'D:/GNT/xdelta3.exe'
+DEFAULT_VANILLA_PATH = 'D:/GNT/GNT4.iso'
+
+prev_scon4 = input('Path to previous SCON4: ')
+if not os.path.isfile(prev_scon4):
+    print(f'{prev_scon4} is not a valid file')
+    sys.exit(1)
+new_scon4 = input('Path to new SCON4: ')
+if not os.path.isfile(new_scon4):
+    print(f'{new_scon4} is not a valid file')
+    sys.exit(1)
+version_name = input('Version name: ')
+
+subprocess.call([DEFAULT_XDELTA3_PATH, "-S", 'none', '-vfs', DEFAULT_VANILLA_PATH, new_scon4, 'vanilla.xdelta'])
+subprocess.call([DEFAULT_XDELTA3_PATH, "-S", 'none', '-vfs', prev_scon4, new_scon4, 'previous.xdelta'])
+
+with open(prev_scon4, "rb") as f:
+    bytes_read = f.read()
+    prev_hash = zlib.crc32(bytes_read) & 0xffffffff
+    hash_display = "0x%0.8x" % prev_hash
+
+with open('patches.csv', 'w') as out:
+    out.write('0x55ee8b1a,vanilla.xdelta\n')
+    out.write(f'{hash_display},previous.xdelta\n')
+
+output = f'''
+    patches:
+      - name: '{version_name}'
+        file: previous.xdelta
+        crc: {hash_display}
+      - name: '{version_name}'
+        file: vanilla.xdelta
+        crc: 0x55ee8b1a
+'''
+print(output)


### PR DESCRIPTION
Add a way to automatically flex the gnt4.online patcher to select the correct patch when the user either provides a vanilla dump or the previous SCON4 version.